### PR TITLE
Enhancements to Java Grammar Parsing  

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ generateAntlrTask := {
   val antlrGeneratorLib = "lib/antlr-4.13.2-complete.jar"
   val outputDirectory = "src/main/java/de/students/antlr"
   val packageName = "de.students.antlr"
-  val inputGrammarFile = "src/main/antlr4/de/students/antlr/Decaf.g4"
+  val inputGrammarFile = "src/main/antlr4/de/students/antlr/Java.g4"
 
   val cmd = s"java -jar ${antlrGeneratorLib} -o ${outputDirectory} -package ${packageName} -listener -visitor -Xexact-output-dir ${inputGrammarFile}"
   println(s" > Executing\n > ${cmd}")

--- a/input/secondinput.java
+++ b/input/secondinput.java
@@ -18,6 +18,9 @@ public class MyProgram {
 
       public static void main(String[] args) {
             MyProgram prog = new MyProgram();
+            (new A()).getB().getNumber(); // this is valid
+
+
             int result = prog.calculate(5, 3);
       }
 }

--- a/input/secondinput.java
+++ b/input/secondinput.java
@@ -1,9 +1,23 @@
-def int add(int x, int y)
-      {  return x + y;
+package mypackage;
+
+public class MyProgram {
+
+      private int count = 10;
+
+      public MyProgram() {
+            this.count = 0;
       }
-      def int main()
-      {
-      int a;
-      a = 3;
-      return add(a, 2);
+
+      public int calculate(int a, int b) {
+            if (a > b) {
+                  return a - b;
+            } else {
+                  return a + b;
+            }
       }
+
+      public static void main(String[] args) {
+            MyProgram prog = new MyProgram();
+            int result = prog.calculate(5, 3);
+      }
+}

--- a/src/main/antlr4/de/students/antlr/Java.g4
+++ b/src/main/antlr4/de/students/antlr/Java.g4
@@ -38,9 +38,9 @@ parameterList: parameter (',' parameter)*;
 parameter: type IDENTIFIER;
 
 // Method Body
-methodBody: '{' block* '}';
+methodBody:  '{' block* '}' ;
 
-block: statement | expression;
+block:  statement |  expression ;
 
 // Statements
 statement: variableDeclaration
@@ -57,7 +57,14 @@ statement: variableDeclaration
 variableDeclaration: type IDENTIFIER ('=' expression)? SC;
 expressionStatement: expression SC;
 returnStatement: RETURN expression? SC;
-ifStatement: 'if' '(' expression ')' block ('else' block)?;
+
+ifStatement: 'if' '(' expression ')' '{' block '}'
+              (elseifStatement)* // Allow multiple else-if blocks
+              (elseStatement)?;
+
+elseifStatement: 'else if' '{' '(' expression ')' block '}';
+elseStatement: 'else' '{' block '}';
+
 whileStatement: 'while' '(' expression ')' block;
 doWhileStatement: 'do' block 'while' '(' expression ')' SC;
 forStatement: 'for' '(' (variableDeclaration | expressionStatement | SC)
@@ -72,12 +79,18 @@ continueStatement: 'continue' SC;
 // Expressions
 expression: literal
           | methodCall
+          | thisAccess
           | IDENTIFIER
           | 'new' type ('(' argumentList? ')' | '[' expression ']') // Object or array creation
           | '(' expression ')'
           | expression operator expression;
 
-methodCall: IDENTIFIER '(' argumentList? ')';
+thisAccess: 'this' '.' IDENTIFIER;
+classAccess: IDENTIFIER '.' IDENTIFIER;
+
+// Method Calls
+methodCall: (IDENTIFIER | thisAccess | classAccess) '(' argumentList? ')';
+
 argumentList: expression (',' expression)*;
 
 // Operators

--- a/src/main/antlr4/de/students/antlr/Java.g4
+++ b/src/main/antlr4/de/students/antlr/Java.g4
@@ -89,7 +89,7 @@ thisAccess: 'this' '.' IDENTIFIER;
 classAccess: IDENTIFIER '.' IDENTIFIER;
 
 // Method Calls
-methodCall: (IDENTIFIER | thisAccess | classAccess) '(' argumentList? ')';
+methodCall: (IDENTIFIER | thisAccess | classAccess ) '(' argumentList? ')';
 
 argumentList: expression (',' expression)*;
 
@@ -121,7 +121,7 @@ PRIMITIVE_TYPE: 'int' | 'char' | 'boolean';
 // Literals
 INTEGER_LITERAL: [0-9]+;
 CHAR_LITERAL: '\'' . '\'';
-STRING_LITERAL: '"' .*? '"';
+STRING_LITERAL: '"' (~["\\\r\n] | '\\' .)* '"';
 BOOLEAN_LITERAL: 'true' | 'false';
 NULL_LITERAL: 'null';
 

--- a/src/main/antlr4/de/students/antlr/Java.g4
+++ b/src/main/antlr4/de/students/antlr/Java.g4
@@ -76,8 +76,21 @@ switchCase: 'case' literal ':' block
 breakStatement: 'break' SC;
 continueStatement: 'continue' SC;
 
+
+// A primary expression can be an identifier, 'this', a class access, or a method call
+primary: IDENTIFIER
+       | thisAccess
+       | classAccess
+       | '(' expression ')'
+       ;
+
+// Method calls, allowing chaining without left recursion
+methodCall: primary ('.' IDENTIFIER '(' argumentList? ')')*;
+
+
 // Expressions
 expression: literal
+          | primary
           | methodCall
           | thisAccess
           | IDENTIFIER
@@ -88,8 +101,6 @@ expression: literal
 thisAccess: 'this' '.' IDENTIFIER;
 classAccess: IDENTIFIER '.' IDENTIFIER;
 
-// Method Calls
-methodCall: (IDENTIFIER | thisAccess | classAccess ) '(' argumentList? ')';
 
 argumentList: expression (',' expression)*;
 

--- a/src/main/antlr4/de/students/antlr/Java.g4
+++ b/src/main/antlr4/de/students/antlr/Java.g4
@@ -1,0 +1,35 @@
+grammar Java;
+
+package: PACKAGE id class ; //| 'package' id abstractclass ;
+
+/*
+abstractclass : 'abstract class' id abstractclassbody;
+abstractclassbody: 'not started yet';
+*/
+
+class: CLASS id classbody | CLASS id EXTENDS id classbody ;
+classbody: '{' method* attribute* '}';
+
+method : modifier;
+attribute : 'help';
+
+modifier: PRIVATE | PUBLIC | PROTECTED | STATIC;
+optionalModifier: modifier?;
+
+
+
+id : IDENTIFIER;
+
+// Keywords
+CLASS : 'class';
+EXTENDS : 'extends';
+PACKAGE : 'package';
+PUBLIC : 'public';
+PRIVATE : 'private';
+PROTECTED : 'protected';
+STATIC : 'static';
+VOID : 'void';
+RETURN : 'return';
+IDENTIFIER : [a-zA-Z_$][a-zA-Z0-9_$]*;
+WS : [ \t\r\n] -> skip;
+

--- a/src/main/antlr4/de/students/antlr/Java.g4
+++ b/src/main/antlr4/de/students/antlr/Java.g4
@@ -1,35 +1,96 @@
 grammar Java;
 
-package: PACKAGE id class ; //| 'package' id abstractclass ;
+// Package Definition
+package: PACKAGE id SC class  ;
 
-/*
-abstractclass : 'abstract class' id abstractclassbody;
-abstractclassbody: 'not started yet';
-*/
+// Class Definitions
+class: CLASS id classbody
+     | CLASS id EXTENDS id classbody ;
 
-class: CLASS id classbody | CLASS id EXTENDS id classbody ;
-classbody: '{' method* attribute* '}';
+classbody: '{' (method | attribute)* '}';
 
-method : modifier;
-attribute : 'help';
+// Methods
+defaultMethod: RETURN returntype IDENTIFIER '(' parameterList? ')' methodBody;
+staticMethod : modifier STATIC returntype IDENTIFIER '(' parameterList? ')' methodBody;
 
+method: staticMethod | defaultMethod;
+
+// Attributes
+attribute: optionalModifier type IDENTIFIER ('=' expression)? SC;
+
+// Modifiers
 modifier: PRIVATE | PUBLIC | PROTECTED | STATIC;
 optionalModifier: modifier?;
 
+// Return Types
+returntype: VOID | type;
 
+// Types
+type: PRIMITIVE_TYPE
+    | id            // user-defined types
+    | type '[]';    // array types
 
-id : IDENTIFIER;
+// Parameter List
+parameterList: parameter (',' parameter)*;
+parameter: type IDENTIFIER;
+
+// Method Body
+methodBody: '{' block* '}';
+
+block : statement | expression;
+
+// Statements
+statement: variableDeclaration
+         | expressionStatement
+         | returnStatement
+         | ifStatement
+         | whileStatement;
+
+variableDeclaration: type IDENTIFIER ('=' expression)? SC;
+expressionStatement: expression SC;
+returnStatement: RETURN expression? SC;
+ifStatement: 'if' '(' expression ')' statement ('else' statement)?;
+whileStatement: 'while' '(' expression ')' statement;
+
+// Expressions
+expression: IDENTIFIER
+          | literal
+          | expression operator expression
+          | '(' expression ')';
+
+// Operators
+operator: '+' | '-' | '*' | '/' | '==' | '!=' | '<' | '>' | '<=' | '>=';
+
+// Literals
+literal: INTEGER_LITERAL | CHAR_LITERAL  | BOOLEAN_LITERAL;
 
 // Keywords
-CLASS : 'class';
-EXTENDS : 'extends';
-PACKAGE : 'package';
-PUBLIC : 'public';
-PRIVATE : 'private';
-PROTECTED : 'protected';
-STATIC : 'static';
-VOID : 'void';
-RETURN : 'return';
-IDENTIFIER : [a-zA-Z_$][a-zA-Z0-9_$]*;
-WS : [ \t\r\n] -> skip;
+CLASS: 'class';
+EXTENDS: 'extends';
+PACKAGE: 'package';
+PUBLIC: 'public';
+PRIVATE: 'private';
+PROTECTED: 'protected';
+STATIC: 'static';
+VOID: 'void';
+RETURN: 'return';
 
+// Primitive Types
+PRIMITIVE_TYPE: 'int' | 'char' | 'boolean' ;
+
+// Literals
+INTEGER_LITERAL: [0-9]+;
+CHAR_LITERAL: '\'' . '\'';
+//STRING_LITERAL: '"' .*? '"';
+BOOLEAN_LITERAL: 'true' | 'false';
+
+// Identifiers
+id: IDENTIFIER;
+IDENTIFIER: [a-zA-Z_$][a-zA-Z0-9_$]*;
+
+SC : ';';
+
+// Whitespace and Comments
+WS: [ \t\r\n]+ -> skip;
+COMMENT: '//' ~[\r\n]* -> skip;
+MULTILINE_COMMENT: '/*' .*? '*/' -> skip;

--- a/src/main/antlr4/de/students/antlr/Java.g4
+++ b/src/main/antlr4/de/students/antlr/Java.g4
@@ -1,16 +1,16 @@
 grammar Java;
 
 // Package Definition
-package: PACKAGE id SC class  ;
+package: PACKAGE id SC class ;
 
 // Class Definitions
-class: CLASS id classbody
-     | CLASS id EXTENDS id classbody ;
+class: PUBLIC? CLASS id classbody
+     | PUBLIC? CLASS id EXTENDS id classbody ;
 
-classbody: '{' (method | attribute)* '}';
+classbody: '{' (method | attribute | constructor)* '}';
 
 // Methods
-defaultMethod: RETURN returntype IDENTIFIER '(' parameterList? ')' methodBody;
+defaultMethod: modifier returntype IDENTIFIER '(' parameterList? ')' methodBody;
 staticMethod : modifier STATIC returntype IDENTIFIER '(' parameterList? ')' methodBody;
 
 method: staticMethod | defaultMethod;
@@ -18,8 +18,11 @@ method: staticMethod | defaultMethod;
 // Attributes
 attribute: optionalModifier type IDENTIFIER ('=' expression)? SC;
 
+// Constructors
+constructor: PUBLIC? id '(' parameterList? ')' methodBody;
+
 // Modifiers
-modifier: PRIVATE | PUBLIC | PROTECTED | STATIC;
+modifier: PRIVATE | PUBLIC | PROTECTED | STATIC | FINAL | ABSTRACT;
 optionalModifier: modifier?;
 
 // Return Types
@@ -37,32 +40,54 @@ parameter: type IDENTIFIER;
 // Method Body
 methodBody: '{' block* '}';
 
-block : statement | expression;
+block: statement | expression;
 
 // Statements
 statement: variableDeclaration
          | expressionStatement
          | returnStatement
          | ifStatement
-         | whileStatement;
+         | whileStatement
+         | forStatement
+         | doWhileStatement
+         | switchStatement
+         | breakStatement
+         | continueStatement;
 
 variableDeclaration: type IDENTIFIER ('=' expression)? SC;
 expressionStatement: expression SC;
 returnStatement: RETURN expression? SC;
-ifStatement: 'if' '(' expression ')' statement ('else' statement)?;
-whileStatement: 'while' '(' expression ')' statement;
+ifStatement: 'if' '(' expression ')' block ('else' block)?;
+whileStatement: 'while' '(' expression ')' block;
+doWhileStatement: 'do' block 'while' '(' expression ')' SC;
+forStatement: 'for' '(' (variableDeclaration | expressionStatement | SC)
+                 expression? SC
+                 expression? ')' block;
+switchStatement: 'switch' '(' expression ')' '{' switchCase* '}';
+switchCase: 'case' literal ':' block
+          | 'default' ':' block;
+breakStatement: 'break' SC;
+continueStatement: 'continue' SC;
 
 // Expressions
-expression: IDENTIFIER
-          | literal
-          | expression operator expression
-          | '(' expression ')';
+expression: literal
+          | methodCall
+          | IDENTIFIER
+          | 'new' type ('(' argumentList? ')' | '[' expression ']') // Object or array creation
+          | '(' expression ')'
+          | expression operator expression;
+
+methodCall: IDENTIFIER '(' argumentList? ')';
+argumentList: expression (',' expression)*;
 
 // Operators
-operator: '+' | '-' | '*' | '/' | '==' | '!=' | '<' | '>' | '<=' | '>=';
+operator: '+' | '-' | '*' | '/' | '%'
+        | '==' | '!=' | '<' | '<=' | '>' | '>='
+        | '&&' | '||'
+        | '=' | '+=' | '-=' | '*=' | '/=' | '%=';
 
 // Literals
-literal: INTEGER_LITERAL | CHAR_LITERAL  | BOOLEAN_LITERAL;
+literal: INTEGER_LITERAL | CHAR_LITERAL | BOOLEAN_LITERAL | STRING_LITERAL | NULL_LITERAL;
 
 // Keywords
 CLASS: 'class';
@@ -72,23 +97,26 @@ PUBLIC: 'public';
 PRIVATE: 'private';
 PROTECTED: 'protected';
 STATIC: 'static';
+FINAL: 'final';
+ABSTRACT: 'abstract';
 VOID: 'void';
 RETURN: 'return';
 
 // Primitive Types
-PRIMITIVE_TYPE: 'int' | 'char' | 'boolean' ;
+PRIMITIVE_TYPE: 'int' | 'char' | 'boolean';
 
 // Literals
 INTEGER_LITERAL: [0-9]+;
 CHAR_LITERAL: '\'' . '\'';
-//STRING_LITERAL: '"' .*? '"';
+STRING_LITERAL: '"' .*? '"';
 BOOLEAN_LITERAL: 'true' | 'false';
+NULL_LITERAL: 'null';
 
 // Identifiers
 id: IDENTIFIER;
 IDENTIFIER: [a-zA-Z_$][a-zA-Z0-9_$]*;
 
-SC : ';';
+SC: ';';
 
 // Whitespace and Comments
 WS: [ \t\r\n]+ -> skip;

--- a/src/main/java/de/students/InputOutput.scala
+++ b/src/main/java/de/students/InputOutput.scala
@@ -37,4 +37,20 @@ class InputOutput {
 
     if (fileContents.nonEmpty) Some(fileContents.mkString("\n")) else None
   }
+
+  def getInput(args: Array[String]):String = {
+    // Check if arguments are provided
+    if (args.isEmpty) {
+      new Exception("No input folder or files were specified in the arguments.")
+    }
+
+    val io = new InputOutput
+    val input = loadFiles(args)
+
+    input match {
+      case Some(content) => content
+      case None => new Exception("No input folder or files were specified in the arguments."); ""
+
+    }
+  }
 }

--- a/src/main/java/de/students/MiniJavaCompiler.scala
+++ b/src/main/java/de/students/MiniJavaCompiler.scala
@@ -2,7 +2,7 @@ package de.students
 
 import de.dhbw.horb.Compiler
 
-import Parser.Parser;
+import Parser.Parser
 
 import de.students.InputOutput
 

--- a/src/main/java/de/students/MiniJavaCompiler.scala
+++ b/src/main/java/de/students/MiniJavaCompiler.scala
@@ -2,6 +2,8 @@ package de.students
 
 import de.dhbw.horb.Compiler
 
+import Parser.Parser;
+
 import de.students.InputOutput
 
 object MiniJavaCompiler {
@@ -23,6 +25,8 @@ object MiniJavaCompiler {
       case None => println("No content could be loaded from the specified paths.")
     }
   }
+
+  Parser.main()
   // val ast = Compiler.generateAST(inputString)
 
   // TODO do something useful with the ast

--- a/src/main/java/de/students/MiniJavaCompiler.scala
+++ b/src/main/java/de/students/MiniJavaCompiler.scala
@@ -9,24 +9,15 @@ import de.students.InputOutput
 object MiniJavaCompiler {
 
   def main(args: Array[String]): Unit = {
-
-
-    // Check if arguments are provided
-    if (args.isEmpty) {
-      println("No input folder or files were specified in the arguments.")
-      return
-    }
-
-    val io = new InputOutput
-    val input = io.loadFiles(args)
-
-    input match {
-      case Some(content) => println(content)
-      case None => println("No content could be loaded from the specified paths.")
+    if(args.nonEmpty) {
+      var io = new InputOutput
+      val input = io.getInput(args)
+      Parser.main(input)
     }
   }
 
-  Parser.main()
+
+
   // val ast = Compiler.generateAST(inputString)
 
   // TODO do something useful with the ast

--- a/src/main/java/de/students/Parser/AST.scala
+++ b/src/main/java/de/students/Parser/AST.scala
@@ -1,0 +1,45 @@
+package de.students.Parser
+
+// Basis-Node für alle AST-Knoten
+sealed trait ASTNode
+
+// Programm-Knoten
+case class Program(classes: List[ClassDecl]) extends ASTNode
+
+// Klassendeklaration
+case class ClassDecl(
+                      name: String,
+                      parent: Option[String],
+                      methods: List[MethodDecl],
+                      fields: List[VarDecl]
+                    ) extends ASTNode
+
+// Methodendeklaration
+case class MethodDecl(
+                       name: String,
+                       returnType: Type,
+                       params: List[VarDecl],
+                       body: List[Statement]
+                     ) extends ASTNode
+
+// Variablendeklaration
+case class VarDecl(name: String, varType: Type) extends ASTNode
+
+// Typen
+sealed trait Type
+case object IntType extends Type
+case object VoidType extends Type
+case class ArrayType(baseType: Type) extends Type
+case class UserType(name: String) extends Type
+
+// Statements
+sealed trait Statement extends ASTNode
+case class ReturnStatement(expr: Option[Expression]) extends Statement
+case class IfStatement(cond: Expression, thenBranch: Statement, elseBranch: Option[Statement]) extends Statement
+case class WhileStatement(cond: Expression, body: Statement) extends Statement
+
+// Ausdrücke
+sealed trait Expression extends ASTNode
+case class VarRef(name: String) extends Expression
+case class Literal(value: Any) extends Expression
+case class BinaryOp(left: Expression, op: String, right: Expression) extends Expression

--- a/src/main/java/de/students/Parser/AST.scala
+++ b/src/main/java/de/students/Parser/AST.scala
@@ -1,12 +1,12 @@
 package de.students.Parser
 
-// Basis-Node für alle AST-Knoten
+// basic node for all AST-trees
 sealed trait ASTNode
 
-// Programm-Knoten
+// Program-node
 case class Program(classes: List[ClassDecl]) extends ASTNode
 
-// Klassendeklaration
+// Class declaration
 case class ClassDecl(
                       name: String,
                       parent: Option[String],
@@ -14,7 +14,7 @@ case class ClassDecl(
                       fields: List[VarDecl]
                     ) extends ASTNode
 
-// Methodendeklaration
+// method declaration
 case class MethodDecl(
                        name: String,
                        returnType: Type,
@@ -22,23 +22,23 @@ case class MethodDecl(
                        body: List[Statement]
                      ) extends ASTNode
 
-// Variablendeklaration
+// variable declaration
 case class VarDecl(name: String, varType: Type) extends ASTNode
 
-// Typen
+// types
 sealed trait Type
 case object IntType extends Type
 case object VoidType extends Type
 case class ArrayType(baseType: Type) extends Type
 case class UserType(name: String) extends Type
 
-// Statements
+// statements
 sealed trait Statement extends ASTNode
 case class ReturnStatement(expr: Option[Expression]) extends Statement
 case class IfStatement(cond: Expression, thenBranch: Statement, elseBranch: Option[Statement]) extends Statement
 case class WhileStatement(cond: Expression, body: Statement) extends Statement
 
-// Ausdrücke
+// expressions
 sealed trait Expression extends ASTNode
 case class VarRef(name: String) extends Expression
 case class Literal(value: Any) extends Expression

--- a/src/main/java/de/students/Parser/Parser.scala
+++ b/src/main/java/de/students/Parser/Parser.scala
@@ -1,0 +1,28 @@
+package de.students.Parser
+import org.antlr.v4.runtime._
+import org.antlr.v4.runtime.tree._
+import de.students.antlr.*
+
+object Parser {
+  def main(): Unit = {
+    // MiniJava-Quellcode einlesen
+    val input = CharStreams.fromFileName("input/secondinput.java")
+
+    // Lexer erzeugen
+    val lexer = new JavaLexer(input)
+
+    // Tokenstream erstellen
+    val tokens = new CommonTokenStream(lexer)
+
+    // Parser erzeugen
+    val parser = new JavaParser(tokens)
+
+    // Parsetree erzeugen
+    val tree = parser.package_()
+
+    // Parsetree debuggen 
+    println(tree.toStringTree(parser))
+
+   
+  }
+}

--- a/src/main/java/de/students/Parser/Parser.scala
+++ b/src/main/java/de/students/Parser/Parser.scala
@@ -6,7 +6,7 @@ import de.students.antlr.*
 object Parser {
   def main(inputString : String): Unit = {
     // convert to CharStream
-    val input = CharStreams.fromString(inputString);
+    val input = CharStreams.fromString(inputString)
     // generate Lexer
     val lexer = new JavaLexer(input)
 

--- a/src/main/java/de/students/Parser/Parser.scala
+++ b/src/main/java/de/students/Parser/Parser.scala
@@ -4,23 +4,22 @@ import org.antlr.v4.runtime.tree._
 import de.students.antlr.*
 
 object Parser {
-  def main(): Unit = {
-    // MiniJava-Quellcode einlesen
-    val input = CharStreams.fromFileName("input/secondinput.java")
-
-    // Lexer erzeugen
+  def main(inputString : String): Unit = {
+    // convert to CharStream
+    val input = CharStreams.fromString(inputString);
+    // generate Lexer
     val lexer = new JavaLexer(input)
 
-    // Tokenstream erstellen
+    // tokenize
     val tokens = new CommonTokenStream(lexer)
 
-    // Parser erzeugen
+    // generate parser
     val parser = new JavaParser(tokens)
 
-    // Parsetree erzeugen
+    // generate parsetree
     val tree = parser.package_()
 
-    // Parsetree debuggen 
+    // print parsetree
     println(tree.toStringTree(parser))
 
    


### PR DESCRIPTION

Hey ,

This PR introduces our Java grammar to implement the discussed features and ensures it can now parse the extensive example provided in `secondinput.java`.  

## What’s Implemented?  
### 1. Package and Class Parsing  
Support for packages and classes with attributes and methods:  
```java
package mypackage;

public class MyClass {
    private int value;

    public int calculate(int a, int b) {
        return a + b;
    }
    
    public static void main(){
       5 + calculate(2,3);
    }
}
```
### 2. Variable Assignments with Method Calls  
You can now parse declarations like:  
```java
int result = prog.calculate(5, 3);
```
This was achieved by extending the variableDeclaration rule to support expressions on the right-hand side. Assignments in general are also now handled via the new assignment rule.

### 3. Expanded Expression Support
Expressions now include:

- Method Calls:
```java
prog.methodCall(arg1, arg2);
```
- Assignments in Expressions:
```java
result = result + 10;
```

### 4. Improved If-Else Parsing
The if rule now supports:

- Full blocks with `{}`
- `else if` chains like:
```java
if (a > b) {
    // do something
} else if (a == b) {
    // do something else
} else {
    // default case
}
```
