### PR TITLE
Access modifiers are optional for attributes

### DIFF
--- a/src/main/scala/de/students/Parser/ASTBuilder.scala
+++ b/src/main/scala/de/students/Parser/ASTBuilder.scala
@@ -426,6 +426,7 @@ object ASTBuilder {
     // Visit an access modifier (PRIVATE, PUBLIC, PROTECTED)
     def visitModifiers(ctx: AccessModifierContext): Option[String] = {
       // Check if the access modifier is present, and return the corresponding string if found
+      if ctx == null then return None // Access modifiers are optional
       if (ctx.PRIVATE() != null) {
         Some("private")
       } else if (ctx.PUBLIC() != null) {


### PR DESCRIPTION
## Motivation
following programms are **both** correct:
```java
 class HelloWorld {
	int value;
        ....
}
```

```java
 class HelloWorld {
	private int value;
        ....
}
```

the old implementation resulted in a NullPointerException because the AccessModifier context could be None