### PR TITLE
Semantic: Rewrite Reflection-Access and union calculation, add member inheritance

### DIFF
--- a/input/multipleClasses.java
+++ b/input/multipleClasses.java
@@ -1,7 +1,5 @@
 package de.multipleclasses;
 
-import java.lang.String;
-
 class AClass {
     private int value;
 
@@ -12,14 +10,9 @@ class AClass {
         BClass b = new BClass();
         AClass a = b.createNewInstance();
         a.calc(this.value);
+        b.calc(this.value);
 
         return n;
-    }
-
-    public String getTestString() {
-        String text = "Hello world";
-
-        return text.substring(1, 3);
     }
 }
 
@@ -28,5 +21,12 @@ class BClass extends AClass {
     public AClass createNewInstance() {
         return new BClass();
     }
+
+
+    // Method calls still runs into problems with the parser
+    // public int heavyCalc() {
+    //    calc(10);
+    //    return 1;
+    // }
 
 }

--- a/input/reflections.java
+++ b/input/reflections.java
@@ -1,0 +1,19 @@
+package de.reflections;
+
+import java.lang.String;
+
+class ReflectionTest {
+
+    public String getTestString() {
+        String text = "Hello world";
+
+        // this requires interfaces, as the parameter of method contains is of type CharSequence
+        // boolean b0 = text.contains("world");
+
+        boolean b1 = text.startsWith("world");
+        boolean b2 = text.startsWith("world", 2);
+
+        return text.substring(1, 3);
+    }
+
+}

--- a/src/main/scala/de/students/Parser/ASTBuilder.scala
+++ b/src/main/scala/de/students/Parser/ASTBuilder.scala
@@ -173,7 +173,7 @@ object ASTBuilder {
         visitWhileStatement(ctx.whileStatement())
       } else if (ctx.doWhileStatement() != null) {
         visitDoWhileStatement(ctx.doWhileStatement())
-      } else if(ctx.forStatement() != null) {
+      } else if (ctx.forStatement() != null) {
         visitForStatement(ctx.forStatement())
       } else {
         // Handle other types of statements
@@ -182,28 +182,28 @@ object ASTBuilder {
     }
 
     override def visitForStatement(ctx: ForStatementContext): Statement = {
-        Logger.debug(s"Visiting for statement: ${ctx.getText}")
+      Logger.debug(s"Visiting for statement: ${ctx.getText}")
 
-        // Parse initialization (either a variable declaration, an expression statement, or empty)
-        val init: Option[Statement] =
-          if (ctx.variableDeclaration() != null) Some(visitVariableDeclaration(ctx.variableDeclaration()))
-          else if (ctx.expressionStatement() != null) Some(visitExpressionStatement(ctx.expressionStatement()))
-          else None
+      // Parse initialization (either a variable declaration, an expression statement, or empty)
+      val init: Option[Statement] =
+        if (ctx.variableDeclaration() != null) Some(visitVariableDeclaration(ctx.variableDeclaration()))
+        else if (ctx.expressionStatement() != null) Some(visitExpressionStatement(ctx.expressionStatement()))
+        else None
 
-        // Parse condition (optional)
-        val cond: Option[Expression] = Option(ctx.expression(0)).map(visitExpression)
+      // Parse condition (optional)
+      val cond: Option[Expression] = Option(ctx.expression(0)).map(visitExpression)
 
-        // Parse update expression (optional)
-        val update: Option[Expression] =
-          if (ctx.expression().size() > 1) Option(visitExpression(ctx.expression(1)))
-          else None
+      // Parse update expression (optional)
+      val update: Option[Expression] =
+        if (ctx.expression().size() > 1) Option(visitExpression(ctx.expression(1)))
+        else None
 
-        // Parse loop body
-        val body: Statement = visitBlockStmt(ctx.block())
+      // Parse loop body
+      val body: Statement = visitBlockStmt(ctx.block())
 
-        Logger.debug(s"For loop - Init: $init, Condition: $cond, Update: $update, Body: $body")
+      Logger.debug(s"For loop - Init: $init, Condition: $cond, Update: $update, Body: $body")
 
-        ForStatement(init, cond, update, body)
+      ForStatement(init, cond, update, body)
     }
 
     override def visitDoWhileStatement(ctx: DoWhileStatementContext): Statement = {
@@ -219,7 +219,7 @@ object ASTBuilder {
       // Return the corresponding AST node for a while statement
       DoWhileStatement(condition, body)
     }
-    
+
     override def visitWhileStatement(ctx: WhileStatementContext): Statement = {
       // Get the condition (expression)
       val condition = visitExpression(ctx.expression())

--- a/src/main/scala/de/students/semantic/ClassAccessHelper.scala
+++ b/src/main/scala/de/students/semantic/ClassAccessHelper.scala
@@ -1,0 +1,140 @@
+package de.students.semantic
+
+import de.students.Parser.{ConstructorDecl, FieldDecl, FunctionType, MethodDecl, Type};
+
+class ClassAccessHelper(bridge: ClassTypeBridge) {
+
+  /**
+   * Get the fully qualified name of the parent of a class with the given fully qualified name
+   *
+   * @param fullyQualifiedClassName The base class, which parent shall be retrieved
+   * @return
+   */
+  def getClassParent(fullyQualifiedClassName: String): String = {
+    if (fullyQualifiedClassName == "java.lang.Object") {
+      throw new SemanticException(s"Forbidden attempt to fetch parent of $fullyQualifiedClassName")
+    }
+
+    val classDecl = bridge.getClass(fullyQualifiedClassName)
+    classDecl.parent
+  }
+
+  /**
+   * Get the fully qualified name of the parent of a class with the given fully qualified name or
+   * None, if the requested class is java.lang.Object
+   *
+   * @param fullyQualifiedClassName The base class, which parent shall be retrieved
+   * @return
+   */
+  def getClassParentOrNone(fullyQualifiedClassName: String): Option[String] = {
+    if (fullyQualifiedClassName == "java.lang.Object") {
+      None
+    } else {
+      val classDecl = bridge.getClass(fullyQualifiedClassName)
+      Some(classDecl.parent)
+    }
+  }
+
+  /**
+   * Retrieve the type of specific member of the given class. This method does work for fields and methods
+   * at the same time. ClassNames in the retrieved type will already be fully qualified
+   *
+   * @param fullyQualifiedClassName The class to search in
+   * @param memberName              The name of the field or method to search
+   * @param methodParams            When searching for a method, this contains the List of parameter types to match overloading.
+   *                                Set to None when searching for fields and List() for methods without parameters
+   * @return
+   */
+  def getClassMemberType(
+    fullyQualifiedClassName: String,
+    memberName: String,
+    methodParams: Option[List[Type]]
+  ): Type = {
+
+    val classDecl = bridge.getClass(fullyQualifiedClassName)
+
+    var matchingMemberType: Option[Type] = None
+
+    // search fields
+    val matchingField: Option[FieldDecl] = classDecl.fields.find(fieldDecl => fieldDecl.name == memberName)
+    matchingMemberType = matchingField match {
+      case Some(field) =>
+        if (methodParams.nonEmpty) {
+          throw new SemanticException(s"Cannot call field ${field.name} of class $fullyQualifiedClassName as a method")
+        } else {
+          Some(field.varType)
+        }
+      case None => None
+    }
+
+    // search method
+    val matchingMethods: List[MethodDecl] = classDecl.methods.filter(methodDecl => {
+      methodDecl.name == memberName && // method has the correct name
+      methodParams.nonEmpty && // we are searching for a method
+      methodDecl.params.size == methodParams.get.size && // number of parameters matches number of arguments
+      methodParams.get.zipWithIndex.forall((providedParam, index) => {
+        val requiredParam = methodDecl.params.apply(index).varType
+        UnionTypeFinder.isASubtypeOfB(requiredParam, providedParam, this)
+      })
+    })
+
+    if (matchingMethods.nonEmpty && matchingMemberType.nonEmpty) {
+      throw new SemanticException(s"Duplicate definition for member name $memberName in class $fullyQualifiedClassName")
+    }
+
+    val matchingMethod: Option[MethodDecl] = matchingMethods.size match {
+      case 0 => None
+      case 1 => Some(matchingMethods.head)
+      case _ =>
+        throw new SemanticException(
+          s"Encountered multiple possible overloaded methods for member $memberName of class $fullyQualifiedClassName with parameter types $methodParams"
+        )
+    }
+
+    matchingMemberType = matchingMethod match {
+      case Some(method) =>
+        if (methodParams.isEmpty) {
+          throw new SemanticException(
+            s"Cannot access method ${method.name} of class $fullyQualifiedClassName as a field"
+          )
+        } else {
+          Some(FunctionType(method.returnType, method.params.map(p => p.varType)))
+        }
+      case None => matchingMemberType
+    }
+
+    matchingMemberType match {
+      case Some(memberType) => memberType
+      case None =>
+        throw new SemanticException(s"No matching member with name $memberName found in class $fullyQualifiedClassName")
+    }
+  }
+
+  /**
+   * Check if the target class contains a constructor that matches the required parameters
+   *
+   * @param fullyQualifiedClassName The class name to search in
+   * @param constructorParams The parameter types, that must match the constructor
+   * @return
+   */
+  def checkClassConstructorWithParameters(fullyQualifiedClassName: String, constructorParams: List[Type]): Boolean = {
+    val classDecl = bridge.getClass(fullyQualifiedClassName)
+
+    val matchingConstructors: List[ConstructorDecl] = classDecl.constructors.filter(constructor => {
+      constructor.params.size == constructorParams.size &&
+      constructor.params.zipWithIndex.forall((requiredParam, index) => {
+        val providedParam = constructorParams.apply(index)
+        UnionTypeFinder.isASubtypeOfB(requiredParam.varType, providedParam, this)
+      })
+    })
+
+    matchingConstructors.size match {
+      case 0 => false
+      case 1 => true
+      case _ =>
+        throw new SemanticException(
+          s"Encountered multiple possible overloaded constructors for class $fullyQualifiedClassName with parameter types $constructorParams"
+        )
+    }
+  }
+}

--- a/src/main/scala/de/students/semantic/SemanticCheck.scala
+++ b/src/main/scala/de/students/semantic/SemanticCheck.scala
@@ -19,7 +19,7 @@ object SemanticCheck {
 
     // create context and make all classes and their fields known to the whole project
     val globalContext = SemanticContext(
-      ClassTypeBridge(project),
+      ClassAccessHelper(ClassTypeBridge(project)),
       mutable.Map[String, Type](),
       mutable.Map[String, String](),
       "",
@@ -106,7 +106,10 @@ object SemanticCheck {
         case Some(methodBody) =>
           val typedMethodBody = StatementChecks.checkStatement(methodBody, methodContext)
           // check if method body type matches method declaration
-          if (!UnionTypeFinder.isASubtypeOfB(typedMethodBody.stmtType, evaluatedReturnType, methodContext)) {
+          if (
+            !UnionTypeFinder
+              .isASubtypeOfB(typedMethodBody.stmtType, evaluatedReturnType, methodContext.getClassAccessHelper)
+          ) {
             throw new SemanticException(
               s"Method ${method.name} in ${methodContext.getClassName} with return type $evaluatedReturnType cannot return value of type ${typedMethodBody.stmtType}"
             )
@@ -141,7 +144,7 @@ object SemanticCheck {
       )
 
       val typedBody: TypedStatement = StatementChecks.checkStatement(constructor.body, methodContext)
-      if (!UnionTypeFinder.isASubtypeOfB(typedBody.stmtType, VoidType, methodContext)) {
+      if (!UnionTypeFinder.isASubtypeOfB(typedBody.stmtType, VoidType, methodContext.getClassAccessHelper)) {
         throw new SemanticException(s"Constructor ${constructor.name} cannot return value")
       }
       ConstructorDecl(constructor.accessModifier, constructor.name, constructor.params, typedBody)

--- a/src/main/scala/de/students/semantic/SemanticContext.scala
+++ b/src/main/scala/de/students/semantic/SemanticContext.scala
@@ -5,7 +5,7 @@ import de.students.Parser.*
 import scala.collection.mutable
 
 class SemanticContext(
-  classTypeBridge: ClassTypeBridge,
+  classAccessHelper: ClassAccessHelper,
   typeAssumptions: mutable.Map[String, Type],
   imports: mutable.Map[String, String],
   packageName: String,
@@ -16,6 +16,7 @@ class SemanticContext(
   def getPackageName: String = packageName
   def getClassName: String = className
   def getTypeAssumption(varName: String): Option[Type] = typeAssumptions.get(varName)
+  def getClassAccessHelper: ClassAccessHelper = classAccessHelper
 
   /**
    * copy the current data and return a new context, optionally with changed
@@ -29,7 +30,7 @@ class SemanticContext(
     newClassName: Option[String] = None
   ): SemanticContext = {
     SemanticContext(
-      classTypeBridge,
+      classAccessHelper,
       typeAssumptions.clone(), // prevent new type assumptions from bubbling up
       if newPackageName.isEmpty then imports else imports.clone(), // if we enter a new package (aka file) context
       newPackageName.getOrElse(packageName),
@@ -55,18 +56,6 @@ class SemanticContext(
       // assume, the class is related to the current package
       usePackage.getOrElse(packageName) + "." + className
     )
-  }
-
-  def getMemberType(fullyQualifiedClassName: String, memberName: String): Type = {
-    this.classTypeBridge.getClassMemberType(fullyQualifiedClassName, memberName)
-  }
-
-  def getClassParent(fullyQualifiedClassName: String): Option[String] = {
-    if (fullyQualifiedClassName == "java.lang.Object") {
-      None
-    } else {
-      Some(this.classTypeBridge.getClassParent(fullyQualifiedClassName))
-    }
   }
 
 }

--- a/src/main/scala/de/students/semantic/StatementChecks.scala
+++ b/src/main/scala/de/students/semantic/StatementChecks.scala
@@ -53,7 +53,7 @@ object StatementChecks {
     // the block type is the combination of all return operations inside the block
     val blockType: Type = typeList.reduce((carry, stmtType) => {
       // combine the new type with the already found types (and throw an error, if not possible)
-      UnionTypeFinder.getUnion(carry, stmtType, context)
+      UnionTypeFinder.getUnion(carry, stmtType, context.getClassAccessHelper)
     })
 
     TypedStatement(
@@ -90,8 +90,9 @@ object StatementChecks {
     }
 
     val stmtType: Type = typedElseBranch match {
-      case Some(elseBranch) => UnionTypeFinder.getUnion(typedThenBranch.stmtType, elseBranch.stmtType, context)
-      case None             => typedThenBranch.stmtType
+      case Some(elseBranch) =>
+        UnionTypeFinder.getUnion(typedThenBranch.stmtType, elseBranch.stmtType, context.getClassAccessHelper)
+      case None => typedThenBranch.stmtType
     }
 
     TypedStatement(IfStatement(typedCondition, typedThenBranch, typedElseBranch), stmtType)
@@ -175,7 +176,7 @@ object StatementChecks {
       .reduce((a: TypedStatement, b: TypedStatement) => {
         TypedStatement(
           BreakStatement(), // placeholder, as we need a statement for the reduce
-          UnionTypeFinder.getUnion(a.stmtType, b.stmtType, context)
+          UnionTypeFinder.getUnion(a.stmtType, b.stmtType, context.getClassAccessHelper)
         )
       })
       .stmtType
@@ -186,7 +187,7 @@ object StatementChecks {
         UnionTypeFinder.getUnion(
           caseUnionType,
           typedDefault.get.caseBlock.asInstanceOf[TypedStatement].stmtType,
-          context
+          context.getClassAccessHelper
         )
 
     TypedStatement(SwitchStatement(typedExpr, typedCases, typedDefault), switchUnionType)


### PR DESCRIPTION
## Summary
1. I was very unsatisfied with the way, the semantic check developed. Some classes became cluttered and lost their specialized area, some union finding was unnecessarily inefficient, etc. TLDR: I rewrote some of it
2. Classes that extend another class should be able to inherit their parents members (access modifiers are ignored for now)
3. Methods with overloaded variants will now be recognized instead of always using the first option

## Changes
- The horrible code in `ClassTypeBridge` was mostly removed and replaced with an easier, encapsulated system, that will return a class in the form of our `ClassDecl` with fully qualified names. If the class should be retrieved from our AST or converted from the Reflection Class will happen automatically and without code duplication
- Duplicated definitions of classes or class members will now be detected and throw a SemanticException when accessed (except Methods with non overlapping parameter types)
- If a member is not found inside a class, then it is searched in the parent class (see ` b.calc(this.value);` in `input/multipleClasses.java`)
- The code for finding Unions has been rewritten to be more efficient in the search

## Testing
As always, just run `sbt "run -- input"` :)