### PR TITLE
Implement unary and assignment operators into semantic check

### DIFF
--- a/input/operations.java
+++ b/input/operations.java
@@ -1,4 +1,4 @@
-package operations;
+package de.operations;
 
 class Operations{
         public static void main(String[] args) {
@@ -9,10 +9,8 @@ class Operations{
             int difference = a - b; // Subtraction
             int product = a * b; // Multiplication
             int quotient = a / b; // Division
-            // int remainder = a % b; // Modulus
-            // int inverse = -a;
+            int remainder = a % b; // Modulus
 
-                
             // Comparison operators
             boolean isEqual = (a == b); // Equal to
             boolean isNotEqual = (a != b); // Not equal to
@@ -26,19 +24,20 @@ class Operations{
             boolean y = false;
             boolean andResult = x && y; // Logical AND
             boolean orResult = x || y; // Logical OR
-            //boolean negation = !x;
+
             // Assignment operators
             int c = 5;
-            /* c += 2; // Equivalent to c = c + 2
-
+            c += 2; // Equivalent to c = c + 2
             c -= 1; // Equivalent to c = c - 1
-
             c *= 3; // Equivalent to c = c * 3
-
             c /= 2; // Equivalent to c = c / 2
-
             c %= 2; // Equivalent to c = c % 2
-            */
+
+            // unary operatos
+            // int inverse = -a;
+            // boolean negation = !x;
+
+
             // Mixed example
             int result = (a + b) * (c - 1); // Using arithmetic operators
             boolean isResultValid = (result > 10) && (result < 50); // Using comparison and logical operators
@@ -46,5 +45,3 @@ class Operations{
         }
 
 }
-
- 


### PR DESCRIPTION
Adding semantic check to #40

# Changes
- Adding support for unary operators `-` and `!` as well as the assignment operators `+=`, `-=`, `*=`, `/=`, `%=`, into the semantic check
- Assignment operators are automatically unboxed: `a += b * c` => `a = a + (b * c)` to prevent further code changes in the bytecode generator
- Unary operators still need to be handled by the bytecode generation 