### PR TITLE
Import wildcards and implicit java.lang.*

### DIFF
--- a/input/objectTests.java
+++ b/input/objectTests.java
@@ -1,7 +1,5 @@
 package de.objecttests;
 
-import java.lang.String;
-
 class HelloWorld {
 	int value;
 

--- a/input/reflections.java
+++ b/input/reflections.java
@@ -1,7 +1,5 @@
 package de.reflections;
 
-import java.lang.String;
-
 class ReflectionTest {
 
     public String getTestString() {

--- a/input/sugarless.java
+++ b/input/sugarless.java
@@ -1,5 +1,6 @@
 package de.sugarless;
 
+import java.lang.*;
 
 class Sugarless extends Object {
 

--- a/input/wildcardImports.java
+++ b/input/wildcardImports.java
@@ -1,0 +1,9 @@
+package de.wildcardimports;
+
+import java.lang.*;
+
+class WildcardImports {
+
+    private String message;
+
+}

--- a/src/main/antlr4/de/students/antlr/Java.g4
+++ b/src/main/antlr4/de/students/antlr/Java.g4
@@ -3,7 +3,7 @@ grammar Java;
 // Package Definition
 package: PACKAGE packageId SC imports class+ ;
 
-imports: (IMPORT packageId SC)* ;
+imports: (IMPORT importPackageId SC)* ;
 
 
 // Class Definitions
@@ -154,6 +154,8 @@ NULL_LITERAL: 'null';
 id: IDENTIFIER;
 IDENTIFIER: [a-zA-Z_$][a-zA-Z0-9_$]*;
 packageId: IDENTIFIER ('.' IDENTIFIER)*;
+importPackageId: IDENTIFIER ('.' IDENTIFIER)* PACKAGE_WILDCARD?;
+PACKAGE_WILDCARD: '.*';
 
 SC: ';';
 

--- a/src/main/scala/de/students/Parser/ASTBuilder.scala
+++ b/src/main/scala/de/students/Parser/ASTBuilder.scala
@@ -40,10 +40,15 @@ object ASTBuilder {
     override def visitImports(ctx: ImportsContext): Imports = {
       Imports(
         ctx
-          .packageId()
+          .importPackageId()
           .asScala
           .map { importCtx =>
-            val importPath = importCtx.IDENTIFIER().asScala.map(_.getText).mkString(".")
+            val diskreteImportPath = importCtx.IDENTIFIER().asScala.map(_.getText).mkString(".")
+            // mark wildcard imports with a dot at the end
+            val importPath =
+              if importCtx.PACKAGE_WILDCARD() == null
+              then diskreteImportPath
+              else diskreteImportPath + "."
             Logger.debug(s"Visiting import $importPath ")
             importPath
           }

--- a/src/main/scala/de/students/semantic/ClassAccessHelper.scala
+++ b/src/main/scala/de/students/semantic/ClassAccessHelper.scala
@@ -1,8 +1,21 @@
 package de.students.semantic
 
-import de.students.Parser.{ConstructorDecl, FieldDecl, FunctionType, MethodDecl, Type};
+import de.students.Parser.*
 
 class ClassAccessHelper(bridge: ClassTypeBridge) {
+
+  /**
+   * Check if a class with the specified class name exists
+   *
+   * @param fullyQualifiedClassName Name of the class to check
+   * @return
+   */
+  def doesClassExist(fullyQualifiedClassName: String): Boolean = {
+    try {
+      bridge.getClass(fullyQualifiedClassName)
+      true
+    } catch case e: SemanticException => false
+  }
 
   /**
    * Get the fully qualified name of the parent of a class with the given fully qualified name
@@ -15,8 +28,7 @@ class ClassAccessHelper(bridge: ClassTypeBridge) {
       throw new SemanticException(s"Forbidden attempt to fetch parent of $fullyQualifiedClassName")
     }
 
-    val classDecl = bridge.getClass(fullyQualifiedClassName)
-    classDecl.parent
+    bridge.getClass(fullyQualifiedClassName).parent
   }
 
   /**
@@ -30,8 +42,9 @@ class ClassAccessHelper(bridge: ClassTypeBridge) {
     if (fullyQualifiedClassName == "java.lang.Object") {
       None
     } else {
-      val classDecl = bridge.getClass(fullyQualifiedClassName)
-      Some(classDecl.parent)
+      Some(
+        bridge.getClass(fullyQualifiedClassName).parent
+      )
     }
   }
 

--- a/src/main/scala/de/students/semantic/SemanticContext.scala
+++ b/src/main/scala/de/students/semantic/SemanticContext.scala
@@ -3,11 +3,13 @@ package de.students.semantic
 import de.students.Parser.*
 
 import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
 
 class SemanticContext(
   classAccessHelper: ClassAccessHelper,
   typeAssumptions: mutable.Map[String, Type],
   imports: mutable.Map[String, String],
+  importWildcards: ListBuffer[String],
   packageName: String,
   className: String
 ) {
@@ -30,16 +32,22 @@ class SemanticContext(
     newClassName: Option[String] = None
   ): SemanticContext = {
     SemanticContext(
-      classAccessHelper,
-      typeAssumptions.clone(), // prevent new type assumptions from bubbling up
-      if newPackageName.isEmpty then imports else imports.clone(), // if we enter a new package (aka file) context
-      newPackageName.getOrElse(packageName),
-      newClassName.getOrElse(className)
+      classAccessHelper = classAccessHelper,
+      typeAssumptions = typeAssumptions.clone(), // prevent new type assumptions from bubbling up
+      imports =
+        if newPackageName.isEmpty then imports else imports.clone(), // if we enter a new package (aka file) context
+      importWildcards = if newPackageName.isEmpty then importWildcards else ListBuffer(),
+      packageName = newPackageName.getOrElse(packageName),
+      className = newClassName.getOrElse(className)
     )
   }
 
   def addImport(className: String, fullyQualifiedClassName: String): Unit = {
-    imports.addOne(className, fullyQualifiedClassName)
+    if (fullyQualifiedClassName.endsWith(".")) {
+      importWildcards.addOne(fullyQualifiedClassName)
+    } else {
+      imports.addOne(className, fullyQualifiedClassName)
+    }
   }
 
   def addTypeAssumption(identifier: String, varType: Type): Unit = {
@@ -50,12 +58,39 @@ class SemanticContext(
   }
 
   def getFullyQualifiedClassName(className: String, usePackage: Option[String] = None): String = {
-    // do not check imports, when a package is specified
-    val importedName: Option[String] = if usePackage.nonEmpty then None else imports.get(className)
-    importedName.getOrElse(
-      // assume, the class is related to the current package
-      usePackage.getOrElse(packageName) + "." + className
-    )
+
+    def assertClassIsDefined = (fqClassName: String) =>
+      if !classAccessHelper.doesClassExist(fqClassName) then
+        throw new SemanticException(s"Referenced class $fqClassName is not defined")
+
+    if (usePackage.nonEmpty) {
+      // use static package name
+      val fqClassName = usePackage.get + className
+      assertClassIsDefined(fqClassName)
+      fqClassName
+    } else if (className.contains(".") && classAccessHelper.doesClassExist(className)) {
+      // the class is already fully qualified
+      className
+    } else if (imports.contains(className)) {
+      // use discrete imports
+      val fqClassName = imports(className)
+      assertClassIsDefined(fqClassName)
+      fqClassName
+    } else {
+      // check if some wildcard contains a matching class
+      val matchingWildcard = importWildcards.find(wildcard =>
+        try {
+          assertClassIsDefined(wildcard + className)
+          true
+        } catch case e: SemanticException => false
+      )
+
+      // use found wildcard or, as a last resort, the current package name
+      val fqClassName =
+        if matchingWildcard.nonEmpty then matchingWildcard.get + className else packageName + "." + className
+      assertClassIsDefined(fqClassName)
+      fqClassName
+    }
   }
 
 }


### PR DESCRIPTION
# Changes
- The grammar and parser now allow for import wildcards like `import java.lang.*`
- If no discrete import matches a simplified class name, every wildcard is tested (from first to last) as the package name of this class. The first match will be used for the fully qualified name, or otherwise the current package is used
- If not specified explicitly, the semantic check will add the `java.lang.*` as an implicit import. This removes the requirement of importing classes like `java.lang.String` or `java.lang.Object`
- This fixed a bug, where an implicit `java.lang.Object` parent would be converted to `<current-package>.Object`

This will resolve #21 