### PR TITLE
Truncate string and char tokens to their contents

### DIFF
--- a/input/primitiveTypes.java
+++ b/input/primitiveTypes.java
@@ -39,9 +39,12 @@ public class primitiveTypes {
         double doubleVar3 = 123.456 * 78.9;
 
         // Char type
-        // char charVar1 = 'A';
-        // char charVar2 = 'B';
-        // char charVar3 = 'C' + 'D';
+        char charVar1 = 'A';
+        char charVar2 = 'B';
+        char charVar3 = 'C' + 'D';
+
+        String s = "Hello world";
+
         return;
     }
 }

--- a/src/main/scala/de/students/Parser/ASTBuilder.scala
+++ b/src/main/scala/de/students/Parser/ASTBuilder.scala
@@ -377,7 +377,7 @@ object ASTBuilder {
       if (ctx.INTEGER_LITERAL() != null) {
         Literal(ctx.INTEGER_LITERAL().getText.toInt)
       } else if (ctx.STRING_LITERAL() != null) {
-        Literal(ctx.STRING_LITERAL().getText)
+        Literal(ctx.STRING_LITERAL().getText.drop(1).dropRight(1))
       } else if (ctx.BOOLEAN_LITERAL() != null) {
         ctx.BOOLEAN_LITERAL().getText match {
           case "true"  => Literal(true)
@@ -395,7 +395,7 @@ object ASTBuilder {
       } else if (ctx.DOUBLE_LITERAL() != null) {
         Literal(ctx.DOUBLE_LITERAL().getText.toDouble)
       } else if (ctx.CHAR_LITERAL() != null) {
-        Literal(ctx.CHAR_LITERAL().getText)
+        Literal(ctx.CHAR_LITERAL().getText.charAt(1))
       } else {
         throw new UnsupportedOperationException(s"Unsupported literal: ${ctx.getText}")
       }


### PR DESCRIPTION
There was a bug in the Parser, that included the quotation marks into the value of literals. 
Instead of a string literal `"hello world"` with value `hello world`, the value was `"hello world"`.
And instead of a char literal `'E'` with value `E` (a single Char), the value was `'E'` (a string with length 3).

This was fixed and the primitiveTypes.java test case works now as intended.