### PR TITLE
More syntactic sugar

### DIFF
--- a/src/main/scala/de/students/ByteCodeGenerator/ASMHelpers.scala
+++ b/src/main/scala/de/students/ByteCodeGenerator/ASMHelpers.scala
@@ -64,8 +64,7 @@ private def javaSignature(t: Type): String = t match {
     val parameters = parameterTypes.map(javaSignature).fold("")((a, b) => a + b)
     f"($parameters)${javaSignature(returnType)}"
   }
-  case NoneType => "" // NOTE should not happen
-  case _        => throw ByteCodeGeneratorException(s"Unknown type $t cannot be converted to ASM-type")
+  case _ => throw ByteCodeGeneratorException(s"Unknown type $t cannot be converted to ASM-type")
 }
 
 private def asmUserType(t: Type): String = t match {

--- a/src/main/scala/de/students/semantic/ExpressionChecks.scala
+++ b/src/main/scala/de/students/semantic/ExpressionChecks.scala
@@ -103,7 +103,7 @@ object ExpressionChecks {
       stackedArrayType = ArrayType(stackedArrayType)
     }
 
-    TypedExpression(NewArray(newArr.arrayType, typedDimensions), stackedArrayType)
+    TypedExpression(NewArray(stackedArrayType, typedDimensions), stackedArrayType)
   }
 
   private def checkNewObjectExpression(newObj: NewObject, context: SemanticContext): TypedExpression = {

--- a/src/main/scala/de/students/semantic/SemanticCheck.scala
+++ b/src/main/scala/de/students/semantic/SemanticCheck.scala
@@ -64,10 +64,9 @@ object SemanticCheck {
       val classContext = context.createChildContext(None, Some(context.getFullyQualifiedClassName(cls.name)))
       // remove syntactic sugar and typeCheck the class
       this.checkClass(
-        SyntacticSugarHandler.handleSyntacticSugar(cls, context),
+        SyntacticSugarHandler.handleSyntacticSugar(cls, classContext),
         classContext
       )
-
     })
     Package(pckg.name, pckg.imports, typedClasses)
   }

--- a/src/main/scala/de/students/semantic/SyntacticSugarHandler.scala
+++ b/src/main/scala/de/students/semantic/SyntacticSugarHandler.scala
@@ -10,10 +10,92 @@ object SyntacticSugarHandler {
   def handleSyntacticSugar(cls: ClassDecl, classContext: SemanticContext): ClassDecl = {
     var updatedClass = cls
 
-    updatedClass = this.moveFieldInitializerToConstructor(updatedClass, classContext)
+    updatedClass = this.addImplicitReturnsAtMethodEnd(updatedClass, classContext)
+    updatedClass = this.moveParameterInitializers(updatedClass, classContext)
+    updatedClass = this.moveFieldInitializers(updatedClass, classContext)
     updatedClass = this.splitVarInitializerFromDeclaration(updatedClass, classContext)
 
     updatedClass
+  }
+
+  /**
+   * Every method must end with a return. If none is specified, an empty return should be added implicitly.
+   * Otherwise, the program execution would be "Falling of the end of the code"
+   *
+   * @param cls          The class to check
+   * @param classContext The current context of the class
+   * @return
+   */
+  private def addImplicitReturnsAtMethodEnd(cls: ClassDecl, classContext: SemanticContext): ClassDecl = {
+    val fixedMethods: List[MethodDecl] = cls.methods.map(method => {
+      if (method.body.isEmpty) {
+        method
+      } else {
+        val bodyBlock = method.body.get.asInstanceOf[BlockStatement]
+
+        if (bodyBlock.stmts.last.isInstanceOf[ReturnStatement]) {
+          method
+        } else {
+          val fixedStmts = bodyBlock.stmts :+ ReturnStatement(None)
+          val fixedBody = BlockStatement(fixedStmts)
+          MethodDecl(
+            method.accessModifier,
+            method.name,
+            method.isAbstract,
+            method.static,
+            method.isFinal,
+            method.returnType,
+            method.params,
+            Some(fixedBody)
+          )
+        }
+      }
+    })
+
+    ClassDecl(cls.name, cls.parent, cls.isAbstract, fixedMethods, cls.fields, cls.constructors)
+  }
+
+  /**
+   * Move the initializer expressions from method parameters to the start of their method
+   *
+   * @param cls          The class to check
+   * @param classContext The current context of the class
+   * @return
+   */
+  private def moveParameterInitializers(cls: ClassDecl, classContext: SemanticContext): ClassDecl = {
+    val fixedMethods: List[MethodDecl] = cls.methods.map(method => {
+
+      val initializerList: ListBuffer[Statement] = ListBuffer()
+      val fixedParameters = method.params.map(param => {
+        if (param.initializer.isEmpty) {
+          param
+        } else {
+          val stmt = StatementExpression(BinaryOp(VarRef(param.name), "=", param.initializer.get))
+          initializerList.addOne(stmt)
+          VarDecl(param.name, param.varType, None)
+        }
+      })
+
+      if (method.body.isEmpty) {
+        method // empty methods have no need for initializers
+      } else {
+        val bodyBlock = method.body.get.asInstanceOf[BlockStatement]
+        val fixedStmts = initializerList.toList ::: bodyBlock.stmts
+        val fixedBody = BlockStatement(fixedStmts)
+        MethodDecl(
+          method.accessModifier,
+          method.name,
+          method.isAbstract,
+          method.static,
+          method.isFinal,
+          method.returnType,
+          fixedParameters,
+          Some(fixedBody)
+        )
+      }
+    })
+
+    ClassDecl(cls.name, cls.parent, cls.isAbstract, fixedMethods, cls.fields, cls.constructors)
   }
 
   /**
@@ -23,10 +105,41 @@ object SyntacticSugarHandler {
    * @param classContext The current context of the class
    * @return
    */
-  private def moveFieldInitializerToConstructor(cls: ClassDecl, classContext: SemanticContext): ClassDecl = {
+  private def moveFieldInitializers(cls: ClassDecl, classContext: SemanticContext): ClassDecl = {
+    val initializerList: ListBuffer[Statement] = ListBuffer()
+    val fixedFields = cls.fields.map(field => {
+      if (field.initializer.isEmpty) {
+        field
+      } else {
+        val stmt = StatementExpression(BinaryOp(ThisAccess(field.name), "=", field.initializer.get))
+        initializerList.addOne(stmt)
+        FieldDecl(field.accessModifier, field.isStatic, field.isFinal, field.name, field.varType, None)
+      }
+    })
 
-    // TODO
-    cls
+    if (initializerList.isEmpty) {
+      return cls
+    }
+
+    // make sure, there is at least one constructor defined
+    val constructors =
+      if cls.constructors.nonEmpty then cls.constructors
+      else
+        List(
+          ConstructorDecl(None, cls.name, List(), BlockStatement(List()))
+        )
+
+    // add the initializers to every constructor
+    val fixedConstructors: List[ConstructorDecl] = constructors.map(constructor => {
+      ConstructorDecl(
+        constructor.accessModifier,
+        constructor.name,
+        constructor.params,
+        BlockStatement(initializerList.toList ::: constructor.body.asInstanceOf[BlockStatement].stmts)
+      )
+    })
+
+    ClassDecl(cls.name, cls.parent, cls.isAbstract, cls.methods, fixedFields, fixedConstructors)
   }
 
   /**

--- a/src/main/scala/de/students/util/ArgParser.scala
+++ b/src/main/scala/de/students/util/ArgParser.scala
@@ -43,7 +43,7 @@ object ArgParser {
     // loop over all arguments to extract the information we need
     while (this.argIndex < this.args.length) {
 
-      val currentArgument = this.getNextArgument()
+      val currentArgument = this.getNextArgument
 
       currentArgument match {
         case "--help" =>
@@ -52,16 +52,22 @@ object ArgParser {
         case "-v"   => this.verbosityLevel = Verbosity.NOTICE
         case "-vv"  => this.verbosityLevel = Verbosity.INFO
         case "-vvv" => this.verbosityLevel = Verbosity.DEBUG
-        case "-o"   => this.outputDirectory = this.getNextArgument()
-        case "-i"   => this.filesToCompile = this.getNextArgument() :: this.filesToCompile
+        case "-o"   => this.outputDirectory = this.getNextArgument
+        case "-i"   => this.filesToCompile = this.getNextArgument :: this.filesToCompile
         case "--"   =>
           // after the delimiter: treat the rest of the arguments as input files
           args
             .slice(this.argIndex, this.args.length)
-            .foreach(arg => this.filesToCompile = this.getNextArgument() :: this.filesToCompile)
+            .foreach(arg => this.filesToCompile = this.getNextArgument :: this.filesToCompile)
           this.argIndex = this.args.length
         case _ => throw new RuntimeException(s"Encountered unknown or unexpected argument \"$currentArgument\"")
       }
+    }
+
+    // fix some inputs to make them compatible across platforms
+    if (this.outputDirectory.startsWith("~/")) {
+      val userHomeDir = System.getProperty("user.home")
+      this.outputDirectory = userHomeDir + this.outputDirectory.drop(1)
     }
   }
 
@@ -70,9 +76,9 @@ object ArgParser {
    *
    * @return The next argument in the input sequence
    */
-  private def getNextArgument(): String = {
+  private def getNextArgument: String = {
     if (this.argIndex >= this.args.length) {
-      throw InputMismatchException("Expected more command line arguments, but got encountered end of input")
+      throw InputMismatchException("Expected more command line arguments, but encountered end of input")
     }
     val arg = this.args(this.argIndex)
     this.argIndex += 1

--- a/src/main/scala/de/students/util/InputOutput.scala
+++ b/src/main/scala/de/students/util/InputOutput.scala
@@ -41,7 +41,6 @@ object InputOutput {
     fileContents
   }
 
-  private val OUT_DIR = Paths.get(".", "out")
   private val CLASS_FILE_ENDING = ".class"
 
   private def writeToBinFile(bytecode: Array[Byte], fullFilepath: String): Unit = {
@@ -52,8 +51,11 @@ object InputOutput {
 
   def writeClassFile(bytecode: ClassBytecode): Unit = {
     val folders = bytecode.className.split('.')
-    val fullFolderPath = folders.reverse.tail.reverse.foldLeft(OUT_DIR)((a, b) => Paths.get(a.toString, b))
+    val outputDirectory = Paths.get(ArgParser.outputDirectory)
+    val fullFolderPath = folders.reverse.tail.reverse.foldLeft(outputDirectory)((a, b) => Paths.get(a.toString, b))
     Files.createDirectories(fullFolderPath)
-    writeToBinFile(bytecode.bytecode, Paths.get(fullFolderPath.toString, folders.last + CLASS_FILE_ENDING).toString)
+    val filePath = Paths.get(fullFolderPath.toString, folders.last + CLASS_FILE_ENDING)
+    Logger.info(s"Writing file: ${filePath.normalize()}")
+    writeToBinFile(bytecode.bytecode, filePath.toString)
   }
 }


### PR DESCRIPTION
Added more desugaring for improved syntax and fixing some cases.

1. Adding implicit void return at the end of methods, that have at least one execution path that does not end with a return statement (this is necessary to prevent "Falling off the edge of the code" errors)
2. Removing field initializers from the fields and adding them to the start of every constructor instead. If no constructor is defined, a new one is created that only contains the initializers

Also, as it was annoying otherwise:
- Removed impossible case from bytecode generator to generalize error cases and disable the warning while compiling
- Applied custom output directory from the cli arguments to the output path