### PR TITLE
Adding typecheck for array members

### DIFF
--- a/input/HelloWorld.java
+++ b/input/HelloWorld.java
@@ -1,0 +1,7 @@
+package helloWorld;
+
+class HelloWorld {
+    public static void main(String[] args) {
+        System.out.println("Hello World");
+    }
+}

--- a/input/main.java
+++ b/input/main.java
@@ -1,17 +1,8 @@
 package de.main;
 
-import java.lang.String;
-
 class Main {
 
     public static void main(String[] args) {
-        /*
-        if (args.length < 1) {
-            System.out.println("Tell me something, and i will repeat!");
-            return;
-        }
-        */
-
         System.out.println(args[0]);
     }
 

--- a/input/main.java
+++ b/input/main.java
@@ -1,8 +1,17 @@
 package de.main;
 
+import java.lang.String;
+
 class Main {
 
     public static void main(String[] args) {
+        /*
+        if (args.length < 1) {
+            System.out.println("Tell me something, and i will repeat!");
+            return;
+        }
+        */
+
         System.out.println(args[0]);
     }
 

--- a/src/main/scala/de/students/ByteCodeGenerator/ASMHelpers.scala
+++ b/src/main/scala/de/students/ByteCodeGenerator/ASMHelpers.scala
@@ -64,8 +64,7 @@ private def javaSignature(t: Type): String = t match {
     val parameters = parameterTypes.map(javaSignature).fold("")((a, b) => a + b)
     f"($parameters)${javaSignature(returnType)}"
   }
-  case NoneType => "" // NOTE should not happen
-  case _        => throw ByteCodeGeneratorException(s"Unknown type $t cannot be converted to ASM-type")
+  case _ => throw ByteCodeGeneratorException(s"Unknown type $t cannot be converted to ASM-type")
 }
 
 private def asmUserType(t: Type): String = t match {

--- a/src/main/scala/de/students/ByteCodeGenerator/ASMHelpers.scala
+++ b/src/main/scala/de/students/ByteCodeGenerator/ASMHelpers.scala
@@ -46,7 +46,7 @@ private def javaifyClass(fullName: String) = makeObjectClassName(fullName.replac
 private def makeObjectClassName(name: String) =
   if name.contains("Object") then "java/lang/Object" else name // TODO temporary, make issue for type check
 
-private def javaSignature(t: Type): String = t match {
+def javaSignature(t: Type): String = t match {
   case IntType             => "I"
   case BoolType            => "Z"
   case VoidType            => "V"

--- a/src/main/scala/de/students/ByteCodeGenerator/Instructions.scala
+++ b/src/main/scala/de/students/ByteCodeGenerator/Instructions.scala
@@ -209,4 +209,19 @@ private object Instructions {
   def storeArray(arrayType: Type, state: MethodGeneratorState): Unit = {
     state.methodVisitor.visitInsn(asmArrayStoreInsn(arrayType))
   }
+
+  def callSuper(parentName: String, state: MethodGeneratorState): Unit = {
+    state.pushStack(UserType(parentName))
+
+    state.methodVisitor.visitVarInsn(ALOAD, 0) // load this
+    state.methodVisitor.visitMethodInsn( // super()
+      INVOKESPECIAL,
+      javaifyClass(parentName),
+      "<init>",
+      "()V",
+      false
+    )
+
+    state.popStack()
+  }
 }

--- a/src/main/scala/de/students/semantic/ClassAccessHelper.scala
+++ b/src/main/scala/de/students/semantic/ClassAccessHelper.scala
@@ -1,5 +1,6 @@
 package de.students.semantic
 
+import de.students.ByteCodeGenerator.javaSignature
 import de.students.Parser.*
 
 class ClassAccessHelper(bridge: ClassTypeBridge) {
@@ -137,6 +138,27 @@ class ClassAccessHelper(bridge: ClassTypeBridge) {
             )
         }
     }
+  }
+
+  /**
+   * Run the member type check for implicit array classes
+   *
+   * @param arrayType   The ArrayType for determining types
+   * @param memberName  The member that should be accessed
+   * @param methodParams  The parameters (if any) to call a method
+   * @return
+   */
+  def getArrayMemberType(
+    arrayType: ArrayType,
+    memberName: String,
+    methodParams: Option[List[Type]]
+  ): Type = {
+    // length is a special property, that does not exist in the reflection and is only supported by the JVM directly
+    if (memberName == "length" && methodParams.isEmpty) {
+      return IntType
+    }
+    val arrayClassName = javaSignature(arrayType).replace('/', '.')
+    this.getClassMemberType(arrayClassName, memberName, methodParams)
   }
 
   /**

--- a/src/main/scala/de/students/semantic/ClassTypeBridge.scala
+++ b/src/main/scala/de/students/semantic/ClassTypeBridge.scala
@@ -99,6 +99,10 @@ class ClassTypeBridge(baseAST: Project) {
    * @return
    */
   private def getLocalClass(fullyQualifiedClassName: String): Option[ClassDecl] = {
+    if (fullyQualifiedClassName.startsWith("[")) {
+      return None // we are searching for an array. These are always handled by the reflection classes
+    }
+
     val (packageName, simpleClassName) = this.splitFullyQualifiedClassName(fullyQualifiedClassName)
 
     val searchResults: List[(ClassDecl, Package)] = baseAST.packages

--- a/src/main/scala/de/students/semantic/ExpressionChecks.scala
+++ b/src/main/scala/de/students/semantic/ExpressionChecks.scala
@@ -134,6 +134,10 @@ object ExpressionChecks {
         val memberType =
           context.getClassAccessHelper.getClassMemberType(qualifiedClassName, memberAccess.memberName, None)
         TypedExpression(MemberAccess(typedTarget, memberAccess.memberName), memberType)
+      case ArrayType(baseType) =>
+        val memberType =
+          context.getClassAccessHelper.getArrayMemberType(ArrayType(baseType), memberAccess.memberName, None)
+        TypedExpression(MemberAccess(typedTarget, memberAccess.memberName), memberType)
       case _ =>
         val iName = if isStatic then "static instance" else "instance"
         throw new SemanticException(

--- a/src/main/scala/de/students/semantic/SyntacticSugarHandler.scala
+++ b/src/main/scala/de/students/semantic/SyntacticSugarHandler.scala
@@ -10,10 +10,92 @@ object SyntacticSugarHandler {
   def handleSyntacticSugar(cls: ClassDecl, classContext: SemanticContext): ClassDecl = {
     var updatedClass = cls
 
-    updatedClass = this.moveFieldInitializerToConstructor(updatedClass, classContext)
+    updatedClass = this.addImplicitReturnsAtMethodEnd(updatedClass, classContext)
+    updatedClass = this.moveParameterInitializers(updatedClass, classContext)
+    updatedClass = this.moveFieldInitializers(updatedClass, classContext)
     updatedClass = this.splitVarInitializerFromDeclaration(updatedClass, classContext)
 
     updatedClass
+  }
+
+  /**
+   * Every method must end with a return. If none is specified, an empty return should be added implicitly.
+   * Otherwise, the program execution would be "Falling of the end of the code"
+   *
+   * @param cls          The class to check
+   * @param classContext The current context of the class
+   * @return
+   */
+  private def addImplicitReturnsAtMethodEnd(cls: ClassDecl, classContext: SemanticContext): ClassDecl = {
+    val fixedMethods: List[MethodDecl] = cls.methods.map(method => {
+      if (method.body.isEmpty) {
+        method
+      } else {
+        val bodyBlock = method.body.get.asInstanceOf[BlockStatement]
+
+        if (bodyBlock.stmts.last.isInstanceOf[ReturnStatement]) {
+          method
+        } else {
+          val fixedStmts = bodyBlock.stmts :+ ReturnStatement(None)
+          val fixedBody = BlockStatement(fixedStmts)
+          MethodDecl(
+            method.accessModifier,
+            method.name,
+            method.isAbstract,
+            method.static,
+            method.isFinal,
+            method.returnType,
+            method.params,
+            Some(fixedBody)
+          )
+        }
+      }
+    })
+
+    ClassDecl(cls.name, cls.parent, cls.isAbstract, fixedMethods, cls.fields, cls.constructors)
+  }
+
+  /**
+   * Move the initializer expressions from method parameters to the start of their method
+   *
+   * @param cls          The class to check
+   * @param classContext The current context of the class
+   * @return
+   */
+  private def moveParameterInitializers(cls: ClassDecl, classContext: SemanticContext): ClassDecl = {
+    val fixedMethods: List[MethodDecl] = cls.methods.map(method => {
+
+      val initializerList: ListBuffer[Statement] = ListBuffer()
+      val fixedParameters = method.params.map(param => {
+        if (param.initializer.isEmpty) {
+          param
+        } else {
+          val stmt = StatementExpression(BinaryOp(VarRef(param.name), "=", param.initializer.get))
+          initializerList.addOne(stmt)
+          VarDecl(param.name, param.varType, None)
+        }
+      })
+
+      if (method.body.isEmpty) {
+        method // empty methods have no need for initializers
+      } else {
+        val bodyBlock = method.body.get.asInstanceOf[BlockStatement]
+        val fixedStmts = initializerList.toList ::: bodyBlock.stmts
+        val fixedBody = BlockStatement(fixedStmts)
+        MethodDecl(
+          method.accessModifier,
+          method.name,
+          method.isAbstract,
+          method.static,
+          method.isFinal,
+          method.returnType,
+          fixedParameters,
+          Some(fixedBody)
+        )
+      }
+    })
+
+    ClassDecl(cls.name, cls.parent, cls.isAbstract, fixedMethods, cls.fields, cls.constructors)
   }
 
   /**
@@ -23,10 +105,41 @@ object SyntacticSugarHandler {
    * @param classContext The current context of the class
    * @return
    */
-  private def moveFieldInitializerToConstructor(cls: ClassDecl, classContext: SemanticContext): ClassDecl = {
+  private def moveFieldInitializers(cls: ClassDecl, classContext: SemanticContext): ClassDecl = {
+    val initializerList: ListBuffer[Statement] = ListBuffer()
+    val fixedFields = cls.fields.map(field => {
+      if (field.initializer.isEmpty) {
+        field
+      } else {
+        val stmt = StatementExpression(BinaryOp(ThisAccess(field.name), "=", field.initializer.get))
+        initializerList.addOne(stmt)
+        FieldDecl(field.accessModifier, field.isStatic, field.isFinal, field.name, field.varType, None)
+      }
+    })
 
-    // TODO
-    cls
+    if (initializerList.isEmpty) {
+      return cls
+    }
+
+    // make sure, there is at least one constructor defined
+    val constructors =
+      if cls.constructors.nonEmpty then cls.constructors
+      else
+        List(
+          ConstructorDecl(None, cls.name, List(), BlockStatement(List()))
+        )
+
+    // add the initializers to every constructor
+    val fixedConstructors: List[ConstructorDecl] = constructors.map(constructor => {
+      ConstructorDecl(
+        constructor.accessModifier,
+        constructor.name,
+        constructor.params,
+        BlockStatement(initializerList.toList ::: constructor.body.asInstanceOf[BlockStatement].stmts)
+      )
+    })
+
+    ClassDecl(cls.name, cls.parent, cls.isAbstract, cls.methods, fixedFields, fixedConstructors)
   }
 
   /**

--- a/src/main/scala/de/students/util/ArgParser.scala
+++ b/src/main/scala/de/students/util/ArgParser.scala
@@ -43,7 +43,7 @@ object ArgParser {
     // loop over all arguments to extract the information we need
     while (this.argIndex < this.args.length) {
 
-      val currentArgument = this.getNextArgument()
+      val currentArgument = this.getNextArgument
 
       currentArgument match {
         case "--help" =>
@@ -52,16 +52,22 @@ object ArgParser {
         case "-v"   => this.verbosityLevel = Verbosity.NOTICE
         case "-vv"  => this.verbosityLevel = Verbosity.INFO
         case "-vvv" => this.verbosityLevel = Verbosity.DEBUG
-        case "-o"   => this.outputDirectory = this.getNextArgument()
-        case "-i"   => this.filesToCompile = this.getNextArgument() :: this.filesToCompile
+        case "-o"   => this.outputDirectory = this.getNextArgument
+        case "-i"   => this.filesToCompile = this.getNextArgument :: this.filesToCompile
         case "--"   =>
           // after the delimiter: treat the rest of the arguments as input files
           args
             .slice(this.argIndex, this.args.length)
-            .foreach(arg => this.filesToCompile = this.getNextArgument() :: this.filesToCompile)
+            .foreach(arg => this.filesToCompile = this.getNextArgument :: this.filesToCompile)
           this.argIndex = this.args.length
         case _ => throw new RuntimeException(s"Encountered unknown or unexpected argument \"$currentArgument\"")
       }
+    }
+
+    // fix some inputs to make them compatible across platforms
+    if (this.outputDirectory.startsWith("~/")) {
+      val userHomeDir = System.getProperty("user.home")
+      this.outputDirectory = userHomeDir + this.outputDirectory.drop(1)
     }
   }
 
@@ -70,9 +76,9 @@ object ArgParser {
    *
    * @return The next argument in the input sequence
    */
-  private def getNextArgument(): String = {
+  private def getNextArgument: String = {
     if (this.argIndex >= this.args.length) {
-      throw InputMismatchException("Expected more command line arguments, but got encountered end of input")
+      throw InputMismatchException("Expected more command line arguments, but encountered end of input")
     }
     val arg = this.args(this.argIndex)
     this.argIndex += 1

--- a/src/main/scala/de/students/util/InputOutput.scala
+++ b/src/main/scala/de/students/util/InputOutput.scala
@@ -41,7 +41,6 @@ object InputOutput {
     fileContents
   }
 
-  private val OUT_DIR = Paths.get(".", "out")
   private val CLASS_FILE_ENDING = ".class"
 
   private def writeToBinFile(bytecode: Array[Byte], fullFilepath: String): Unit = {
@@ -52,8 +51,11 @@ object InputOutput {
 
   def writeClassFile(bytecode: ClassBytecode): Unit = {
     val folders = bytecode.className.split('.')
-    val fullFolderPath = folders.reverse.tail.reverse.foldLeft(OUT_DIR)((a, b) => Paths.get(a.toString, b))
+    val outputDirectory = Paths.get(ArgParser.outputDirectory)
+    val fullFolderPath = folders.reverse.tail.reverse.foldLeft(outputDirectory)((a, b) => Paths.get(a.toString, b))
     Files.createDirectories(fullFolderPath)
-    writeToBinFile(bytecode.bytecode, Paths.get(fullFolderPath.toString, folders.last + CLASS_FILE_ENDING).toString)
+    val filePath = Paths.get(fullFolderPath.toString, folders.last + CLASS_FILE_ENDING)
+    Logger.info(s"Writing file: ${filePath.normalize()}")
+    writeToBinFile(bytecode.bytecode, filePath.toString)
   }
 }


### PR DESCRIPTION
There was no typecheck for array members, as I completely forgot they are internally classes too.
This is now added by this PR to the semantic check.

- This PR is based on the changes of #51, so that should be resolved first (but I highly doubt that there are problems)
- The "length" property is hard coded as IntType, as it is not a field of the array class, but a special keyword, that is handled by the JVM itself
- The class-name of an array is the javaified description of the type. To prevent duplicate code, the method from the bytecode generator was reused

This has to be extended in the bytecode generation to handle array methods and especially the extra length property. Please let me know, if you want to merge these changes before implementing it into the bytecode for any reason.

An example for the use of the length properties is given in `input/main.java`, but commented out. This java class can be compiled with the current state and is fully functional on its own. This should still be possible after the array members are implemented.   