### PR TITLE
Add super keyword

### DIFF
--- a/input/superTest.java
+++ b/input/superTest.java
@@ -1,0 +1,32 @@
+package superTest;
+class Parent {
+    String message = "Hello from Parent";
+
+    // Parent constructor
+    Parent(String name) {
+        System.out.println("Parent Constructor: " + name);
+    }
+
+    void showMessage() {
+        System.out.println("Parent method: " + message);
+    }
+}
+
+class Child extends Parent {
+    String message = "Hello from Child";
+
+    // Child constructor
+    Child(String name) {
+        super(name); // Super constructor call
+        System.out.println("Child Constructor: " + name);
+    }
+
+    void showMessage() {
+        super.showMessage(); // Super method call
+        System.out.println("Child method: " + message);
+    }
+
+    void printParentMessage() {
+        System.out.println("Accessing Parent field: " + super.message); // Super field access
+    }
+}

--- a/src/main/antlr4/de/students/antlr/Java.g4
+++ b/src/main/antlr4/de/students/antlr/Java.g4
@@ -17,9 +17,9 @@ method: accessModifier? STATIC? FINAL? ABSTRACT?  returntype IDENTIFIER '(' para
 // Attributes
 attribute: accessModifier? STATIC? FINAL? type IDENTIFIER ('=' expression)? SC;
 
-// Constructors
-constructor: accessModifier? id '(' parameterList? ')' block;
+constructor: accessModifier? id '(' parameterList? ')' '{' superCall? statement* '}';
 
+superCall: SUPER '(' argumentList? ')' SC;  // Allows calling superclass constructor
 // Modifiers
 accessModifier: PRIVATE | PUBLIC | PROTECTED;  // Only one allowed
 
@@ -97,6 +97,7 @@ postfixExpression
 simplePrimary
     : IDENTIFIER ('(' argumentList? ')')?    // Implicit method call: e.g. calc(10) Variable reference or class name
     | THIS
+    | SUPER  // super.methodName() or super.fieldName
     | literal
     | '(' expression ')'
     | objectCreation
@@ -147,6 +148,8 @@ VOID: 'void';
 RETURN: 'return';
 IMPORT: 'import';
 THIS : 'this';
+SUPER: 'super';
+
 // Primitive Types
 PRIMITIVE_TYPE: 'int' | 'char' | 'boolean' | 'byte' | 'double' | 'float' | 'short' | 'long';
 

--- a/src/main/scala/de/students/Parser/AST.scala
+++ b/src/main/scala/de/students/Parser/AST.scala
@@ -35,6 +35,7 @@ case class MethodDecl(
 // Constructor declaration
 case class ConstructorDecl(
   accessModifier: Option[String],
+  superConstructor: Option[SuperConstructorCall],
   name: String,
   params: List[VarDecl],
   body: Statement
@@ -108,11 +109,19 @@ case class MemberAccess(target: Expression, memberName: String) extends Expressi
 // Represents `this.member`
 case class ThisAccess(name: String) extends Expression
 
+case class SuperAccess(member: Option[String]) extends Expression
+
 case class NewObject(className: String, arguments: List[Expression]) extends Expression
 case class NewArray(arrayType: Type, dimensions: List[Expression]) extends Expression
 case class ArrayAccess(array: Expression, index: Expression) extends Expression
 
 // Method calls (member access with parentheses)
 case class MethodCall(target: Expression, methodName: String, args: List[Expression]) extends Expression
+
+// Represents `super.method(args...)`
+case class SuperMethodCall(methodName: String, args: List[Expression]) extends Expression
+
+// Represents `super(arguments...)` in constructors
+case class SuperConstructorCall(args: List[Expression]) extends Statement
 
 case class TypedExpression(expr: Expression, exprType: Type) extends Expression

--- a/src/main/scala/de/students/Parser/ASTBuilder.scala
+++ b/src/main/scala/de/students/Parser/ASTBuilder.scala
@@ -90,23 +90,24 @@ object ASTBuilder {
       MethodDecl(accesModifier, name, isAbstract, isStatic, isFinal, returnType, params, body)
     }
 
-    override def visitConstructor(ctx: ConstructorContext): ConstructorDecl = {
-      val name = ctx.id().getText // Get the constructor name
-      val accessModifier = visitModifiers(ctx.accessModifier())
+    override def visitConstructor(ctx: JavaParser.ConstructorContext): ConstructorDecl = {
+      val accessModifier = Option(ctx.accessModifier()).map(_.getText)
+      val name = ctx.id().getText
+      val params =
+        if ctx.parameterList() == null then List()
+        else ctx.parameterList().parameter().asScala.map(visitParameter).toList
+      // Extract `superCall` if it exists
+      val superConstructor = Option(ctx.superCall()).map(visitSuperCall)
+      // Extract remaining statements
+      val statements = ctx.statement().asScala.toList.map(visitStatement)
+      // Body contains only the remaining statements (excluding `superCall`)
+      val body = BlockStatement(statements)
+      ConstructorDecl(accessModifier, superConstructor, name, params, body)
+    }
 
-      // Parse parameters
-      val params = if (ctx.parameterList() != null) {
-        ctx.parameterList().parameter().asScala.map(visitParameter).toList
-      } else {
-        List() // No parameters
-      }
-
-      // Parse the method body: Iterate over each block and collect statements
-      val body = visitBlockStmt(ctx.block())
-
-      Logger.debug(s"Visiting constructor: $name, Parameters: $params, Body: $body")
-
-      ConstructorDecl(accessModifier, name, params, body)
+    override def visitSuperCall(ctx: JavaParser.SuperCallContext): SuperConstructorCall = {
+      val args = if (ctx.argumentList() != null) visitMyArgumentList(ctx.argumentList()) else List()
+      SuperConstructorCall(args)
     }
 
     override def visitReturntype(ctx: ReturntypeContext): Type = {
@@ -310,6 +311,8 @@ object ASTBuilder {
         }
       } else if (ctx.THIS() != null) {
         VarRef("this")
+      } else if (ctx.SUPER() != null) {
+        VarRef("super") // Handle as "super" without member access
       } else if (ctx.literal() != null) {
         visitLiteral(ctx.literal())
       } else if (ctx.expression() != null) {
@@ -331,20 +334,15 @@ object ASTBuilder {
       ctx.getChild(0).getText match {
         case "." =>
           val memberName = ctx.IDENTIFIER().getText
-          if (ctx.getChildCount > 2 && ctx.getChild(2).getText == "(") {
-            val args = if (ctx.argumentList() != null) visitMyArgumentList(ctx.argumentList()) else List()
-            MethodCall(target, memberName, args)
-          } else {
-            target match {
-              case VarRef(name) =>
-                if (name == "this")
-                  ThisAccess(memberName)
-                else
-                  MemberAccess(target, memberName)
-
-              case _ =>
-                throw new UnsupportedOperationException("Unsupported postfix usage: " + target)
+          if (target == VarRef("super")) {
+            if (ctx.getChildCount > 2 && ctx.getChild(2).getText == "(") {
+              val args = if (ctx.argumentList() != null) visitMyArgumentList(ctx.argumentList()) else List()
+              SuperMethodCall(memberName, args)
+            } else {
+              SuperAccess(Some(memberName))
             }
+          } else {
+            MemberAccess(target, memberName)
           }
         case "[" =>
           val index = visitExpression(ctx.expression())


### PR DESCRIPTION
## Changes:

- **ANTLR Grammar Updates:**
  - Extended the grammar to handle `super` calls within constructor declarations.
  - Added a `superCall` rule to the constructor declaration to allow proper parsing of `super()` calls in class constructors.
  
- **AST Updates:**
  - Introduced the `SuperConstructorCall` case class to represent `super` calls with arguments inside the AST.
  - Modified the `ConstructorDecl` case class to include an optional `superConstructor` field, allowing the representation of a `super()` call in constructors.

- **ASTBuilder Updates:**
  - Updated the `visitConstructorDecl` method to correctly handle `super` calls within constructors.
  - If a `super()` call is found in the constructor, it is parsed and combined with the other constructor body statements.

## Summary:
This update adds support for parsing and handling `super` constructor calls within Java classes. The changes cover the ANTLR grammar, AST structure, and ASTBuilder logic, ensuring that `super()` calls are captured and processed correctly when building the AST from parsed Java source code.

this PR was moved from #48, which had conflicting changes, which are eliminated with opening this new PR
