### PR TITLE
feat: added checks for access modifiers

### DIFF
--- a/input/accessModifiers.java
+++ b/input/accessModifiers.java
@@ -1,0 +1,22 @@
+package de.accessmodifiers;
+
+class AccessModifiers {
+
+    public void test() {
+        B b = new B();
+        //b.propA; // not possible, because property is private
+        b.propB;
+        b.propC;
+        b.propD;
+    }
+
+}
+
+class B {
+
+    private int propA = 1;
+    protected int propB = 2;
+    public int propC = 3;
+    /* package */ int propD = 4;
+
+}

--- a/src/main/scala/de/students/semantic/CallSource.scala
+++ b/src/main/scala/de/students/semantic/CallSource.scala
@@ -1,0 +1,77 @@
+package de.students.semantic
+
+import de.students.Parser.{FieldDecl, MethodDecl, UserType}
+
+class CallSource(
+  private val staticCall: Boolean,
+  private val context: SemanticContext
+) {
+
+  /**
+   * Assert, that the method can be called and return false otherwise
+   *
+   * @param targetDecl     The method or field declaration, that we attempt to call
+   * @param className      The class name of the target
+   * @return
+   */
+  def assertCanCall(
+    targetDecl: MethodDecl | FieldDecl,
+    className: String
+  ): Unit = {
+    val packageName = this.getPackageNameFromClassName(className)
+
+    var memberName: String = ""
+    var accessModifier: Option[String] = None
+    val canBeCalled = targetDecl match {
+      case methodDecl: MethodDecl =>
+        if (!methodDecl.static && staticCall) {
+          throw new SemanticException(s"Cannot call non-static method $className:${methodDecl.name} in static context")
+        }
+        memberName = methodDecl.name
+        accessModifier = methodDecl.accessModifier
+        this.checkAccessModifier(methodDecl.accessModifier, className, packageName)
+      case fieldDecl: FieldDecl =>
+        memberName = fieldDecl.name
+        accessModifier = fieldDecl.accessModifier
+        this.checkAccessModifier(fieldDecl.accessModifier, className, packageName)
+    }
+
+    if (!canBeCalled) {
+      throw new SemanticException(
+        s"Cannot access ${accessModifier.getOrElse("package")} member $className:$memberName from" +
+          s" ${context.getClassName}"
+      )
+    }
+  }
+
+  /**
+   * Check if the given access modifier matches the correlation of the caller and the called
+   *
+   * @param accessModifier  Either an access modifier or None
+   * @param className       The class name of the target
+   * @return
+   */
+  private def checkAccessModifier(accessModifier: Option[String], className: String, packageName: String): Boolean = {
+    val sourceClassName = context.getClassName
+    val sourcePackageName = context.getPackageName
+
+    accessModifier match {
+      case Some("public") => true // always accessible
+      case Some("protected") => // visible in package and all subclasses
+        sourcePackageName == packageName || UnionTypeFinder.isASubtypeOfB(
+          UserType(sourceClassName),
+          UserType(className),
+          context.getClassAccessHelper
+        )
+      case Some("private") => sourceClassName == className // visible in class only
+      case _               => sourcePackageName == packageName // typically None, visible in package only
+    }
+  }
+
+  private def getPackageNameFromClassName(className: String): String = {
+    val parts = className.split('.')
+    val simpleClassName = parts.last
+    className.dropRight(simpleClassName.length + 1)
+  }
+
+}

--- a/src/main/scala/de/students/semantic/ExpressionChecks.scala
+++ b/src/main/scala/de/students/semantic/ExpressionChecks.scala
@@ -29,16 +29,18 @@ object ExpressionChecks {
         s"Cannot call method ${methodCall.methodName} on value of type ${typedTarget.exprType}"
       )
     }
-    val isStaticTarget = typedTarget.expr.isInstanceOf[StaticClassRef]
-
     // validate arguments
     val typedArguments = methodCall.args.map(argument => ExpressionChecks.checkExpression(argument, context))
     val argTypes = typedArguments.map(arg => arg.exprType)
 
     // determine method definition
     val fqClassName = typedTarget.exprType.asInstanceOf[UserType].name
-    // TODO: if isStaticTarget == true, then filter for static members only!
-    val methodType = context.getClassAccessHelper.getClassMemberType(fqClassName, methodCall.methodName, Some(argTypes))
+
+    val isStaticTarget = typedTarget.expr.isInstanceOf[StaticClassRef]
+    val callSource = CallSource(isStaticTarget, context)
+
+    val methodType =
+      context.getClassAccessHelper.getClassMemberType(fqClassName, methodCall.methodName, Some(argTypes), callSource)
     if (!methodType.isInstanceOf[FunctionType]) {
       throw new SemanticException(
         s"Cannot call member ${methodCall.methodName} of type $methodType as method with parameters of types $argTypes"
@@ -130,9 +132,9 @@ object ExpressionChecks {
 
     typedTarget.exprType match {
       case UserType(qualifiedClassName) =>
-        // TODO: filter for static class members, if isStatic
+        val callSource = CallSource(isStatic, context)
         val memberType =
-          context.getClassAccessHelper.getClassMemberType(qualifiedClassName, memberAccess.memberName, None)
+          context.getClassAccessHelper.getClassMemberType(qualifiedClassName, memberAccess.memberName, None, callSource)
         TypedExpression(MemberAccess(typedTarget, memberAccess.memberName), memberType)
       case _ =>
         val iName = if isStatic then "static instance" else "instance"
@@ -143,7 +145,9 @@ object ExpressionChecks {
   }
 
   private def checkThisAccessExpression(thisAccess: ThisAccess, context: SemanticContext): TypedExpression = {
-    val memberType = context.getClassAccessHelper.getClassMemberType(context.getClassName, thisAccess.name, None)
+    val callSource = CallSource(false, context)
+    val memberType =
+      context.getClassAccessHelper.getClassMemberType(context.getClassName, thisAccess.name, None, callSource)
     TypedExpression(thisAccess, memberType)
   }
 


### PR DESCRIPTION
The Semantic Check does now test method calls and member accesses for the access modifier of the target. If the scope does not match, an error is thrown. This was done by adding a `CallSource` object to the member search. Once a member was found, the callSource Object can be used to check if the source class has access to the target member.
This will finally resolve #25 


### tests
A new test file has been added: `input/accessModifiers.java`. But our example cases cannot check for correct exceptions, so additionally, a new test has been added to the test suite. This will check every combination of access modifiers across two classes in either the same or different packages.